### PR TITLE
Фикс атаки и вот этого вот красненького сообщения снизу

### DIFF
--- a/Assets/Animation/Player/Anim_Atack.fbx.meta
+++ b/Assets/Animation/Player/Anim_Atack.fbx.meta
@@ -69,7 +69,7 @@ ModelImporter:
       bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
       curves: []
       events:
-      - time: 0.61156684
+      - time: 0.13844857
         functionName: OnPlayerAttackEnded
         data: 
         objectReferenceParameter: {instanceID: 0}

--- a/Assets/Scripts/PlayerMovementSound.cs
+++ b/Assets/Scripts/PlayerMovementSound.cs
@@ -25,7 +25,7 @@ public class PlayerMovementSound : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Mouse1))
+        if (Input.GetKeyDown(KeyCode.Mouse1) && SprintSound.Length > 0)
         {
             clipnumber = Random.Range(0, SprintSound.Length);
             source.PlayOneShot(SprintSound[clipnumber]);
@@ -34,12 +34,14 @@ public class PlayerMovementSound : MonoBehaviour
 
     void Step()
     {
-        stepnumber = Random.Range(0, StepSound.Length);
-        source.PlayOneShot(StepSound[stepnumber]);
-
+        if (StepSound.Length > 0)
+        {
+            stepnumber = Random.Range(0, StepSound.Length);
+            source.PlayOneShot(StepSound[stepnumber]);
+        }
     }
-    
-    
+
+
 
 
 }


### PR DESCRIPTION
1) Событие, наносящее урон врагам срабатывало слишком поздно для того, чтобы вощбще понять, что это атакует игрок
2) В спиле играбельных звуков на Атаке игрока было 0 звуков. Вопрос знатокам, сколько будет рандом от нуля до нуля... ноль... а елемента под номером ноль не существует, потому что там их вообще нет...
Вообщем я исправил